### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/zoeylan1015/2a277aa3-1989-45e9-a2d6-f2a03689e947/cebb2df7-cbe7-473b-aa6f-06ff6a350428/_apis/work/boardbadge/9b70979c-1a0e-4b56-ab0c-a05a273e76e0)](https://dev.azure.com/zoeylan1015/2a277aa3-1989-45e9-a2d6-f2a03689e947/_boards/board/t/cebb2df7-cbe7-473b-aa6f-06ff6a350428/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/zoeylan1015/2a277aa3-1989-45e9-a2d6-f2a03689e947/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.